### PR TITLE
Revert "feat(tmux): Automatically adjust status-left-length when renaming sessions."

### DIFF
--- a/tmux/properties.go
+++ b/tmux/properties.go
@@ -1,5 +1,9 @@
 package tmux
 
+import (
+	"fmt"
+)
+
 // properties is a helper function to make implementing property lookups for
 // different tmux entities a little easier.
 // keys are all the properties being fetched.
@@ -13,7 +17,7 @@ func properties[T ~string](keys []T, fn func([]string) ([]string, error)) (map[T
 
 	props, err := fn(keyStrings)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to fetch properties %s: %w", keyStrings, err)
 	}
 	res := make(map[T]string, len(keys))
 	for i, prop := range props {

--- a/tmux/server.go
+++ b/tmux/server.go
@@ -275,10 +275,3 @@ func (srv *Server) resolveTargetSession(s TargetSession) (string, error) {
 func (srv *Server) Kill() error {
 	return srv.command("kill-server").Run()
 }
-
-func (srv *Server) SetOption(opt Option, val string) error {
-	if err := srv.command("set-option", "-s", string(opt), val).Run(); err != nil {
-		return fmt.Errorf("set-option -s %q %q: %w", opt, val, err)
-	}
-	return nil
-}

--- a/tmux/session.go
+++ b/tmux/session.go
@@ -68,7 +68,7 @@ func (s *Session) Property(prop SessionProperty) (string, error) {
 // Properties fetches properties about a session.
 func (s *Session) Properties(props ...SessionProperty) (map[SessionProperty]string, error) {
 	res, err := properties(props, func(keys []string) ([]string, error) {
-		stdout, err := s.DisplayMessage(strings.Join(keys, "\n"))
+		stdout, err := s.Server.command("display-message", "-t", s.ID, "-p", strings.Join(keys, "\n")).RunStdout()
 		if err != nil {
 			return nil, err
 		}
@@ -103,19 +103,4 @@ func (s *Session) Kill() error {
 		return fmt.Errorf("could not kill session %q: %w", s.ID, err)
 	}
 	return nil
-}
-
-func (s *Session) SetOption(opt Option, val string) error {
-	if err := s.Server.command("set-option", "-t", s.ID, string(opt), val).Run(); err != nil {
-		return fmt.Errorf("set-option -t %s %q %q: %w", s.ID, opt, val, err)
-	}
-	return nil
-}
-
-func (s *Session) DisplayMessage(msg string) (string, error) {
-	stdout, err := s.Server.command("display-message", "-t", s.ID, "-p", msg).RunStdout()
-	if err != nil {
-		return "", fmt.Errorf("display-message -t %s %q: %w", s.ID, msg, err)
-	}
-	return stdout, nil
 }

--- a/tmux/state/state.go
+++ b/tmux/state/state.go
@@ -6,7 +6,6 @@ import (
 	"log/slog"
 	"maps"
 	"slices"
-	"strconv"
 	"strings"
 
 	"github.com/JeffFaer/tmux-vcs-sync/api"
@@ -223,34 +222,13 @@ func (st *State) PruneSessions() error {
 func (st *State) updateSessionNames() error {
 	var errs []error
 	for k, sesh := range st.sessions {
-		props, err := sesh.Properties(tmux.SessionName, tmux.StatusLeft.SessionProperty(), tmux.StatusLeftLength.SessionProperty())
+		name, err := sesh.Property(tmux.SessionName)
 		if err != nil {
 			errs = append(errs, err)
 			continue
 		}
-		name := props[tmux.SessionName]
-		statusLeft := props[tmux.StatusLeft.SessionProperty()]
-		statusLeftLength := props[tmux.StatusLeftLength.SessionProperty()]
 		if want := st.sessionNameString(k); name != want {
 			if err := sesh.Rename(want); err != nil {
-				errs = append(errs, err)
-				continue
-			}
-		}
-
-		msg, err := sesh.DisplayMessage(statusLeft)
-		if err != nil {
-			errs = append(errs, err)
-			continue
-		}
-		wantLength := len(msg)
-		got, err := strconv.Atoi(statusLeftLength)
-		if err != nil {
-			errs = append(errs, fmt.Errorf("tmux session %s has invalid %s value %q: %w", sesh.ID, tmux.StatusLeftLength, statusLeftLength, err))
-			continue
-		}
-		if wantLength > got {
-			if err := sesh.SetOption(tmux.StatusLeftLength, strconv.Itoa(wantLength)); err != nil {
 				errs = append(errs, err)
 				continue
 			}

--- a/tmux/tmux.go
+++ b/tmux/tmux.go
@@ -19,14 +19,3 @@ func init() {
 		panic(err)
 	}
 }
-
-type Option string
-
-const (
-	StatusLeft       Option = "status-left"
-	StatusLeftLength Option = "status-left-length"
-)
-
-func (opt Option) SessionProperty() SessionProperty {
-	return SessionProperty(fmt.Sprintf("#{%s}", opt))
-}


### PR DESCRIPTION
I don't actually need to do this. You can just set status-left-length to something big in your own .tmux.conf and tmux will use the space it needs.